### PR TITLE
bugfix - contentNode offset not updated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "scroll-kit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Take care of your elements on the viewport",
   "main": [
     "scroll-kit.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scroll-kit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Take care of your elements on the viewport",
   "main": "scroll-kit.js",
   "scripts": {

--- a/scroll-kit.coffee
+++ b/scroll-kit.coffee
@@ -1,4 +1,4 @@
-VERSION = '0.3.0'
+VERSION = '0.3.1'
 
 offsets = {}
 group_id = 0
@@ -509,6 +509,8 @@ update_everything = (destroy) ->
       .val state.gap.nearest
   return
 
+## not sure about this...
+## also, will not work for new img/iframe created elems
 $('img, iframe').on 'load error', ->
   update_everything()
 
@@ -607,8 +609,10 @@ $.scrollKit.destroy = (node) ->
   # TODO: detach all content-nodes
 
 $.scrollKit.scrollTo = (index, callback) ->
+  sticky  = state.contentNodes[index]
+  _offset = $(sticky).offset()
   html.animate
-    scrollTop: state.contentNodes[index].offset.top - state.offsetTop
+    scrollTop: _offset.top - state.offsetTop
   , 260, 'swing', callback
   return
 

--- a/scroll-kit.coffee
+++ b/scroll-kit.coffee
@@ -609,8 +609,8 @@ $.scrollKit.destroy = (node) ->
   # TODO: detach all content-nodes
 
 $.scrollKit.scrollTo = (index, callback) ->
-  sticky  = state.contentNodes[index]
-  _offset = $(sticky).offset()
+  contentNode  = state.contentNodes[index]
+  _offset = $(contentNode).offset()
   html.animate
     scrollTop: _offset.top - state.offsetTop
   , 260, 'swing', callback

--- a/scroll-kit.js
+++ b/scroll-kit.js
@@ -645,8 +645,11 @@
   };
 
   $.scrollKit.scrollTo = function(index, callback) {
+    var _offset, sticky;
+    sticky = state.contentNodes[index];
+    _offset = $(sticky).offset();
     html.animate({
-      scrollTop: state.contentNodes[index].offset.top - state.offsetTop
+      scrollTop: _offset.top - state.offsetTop
     }, 260, 'swing', callback);
   };
 

--- a/scroll-kit.js
+++ b/scroll-kit.js
@@ -2,7 +2,7 @@
 (function() {
   var VERSION, body, calculate_all_offsets, calculate_all_stickes, check_if_can_bottom, check_if_can_float, check_if_can_sit, check_if_can_stick, check_if_can_unbottom, check_if_can_unstick, check_if_carry, check_if_fit, debug, destroy_sticky, event_handler, group_id, html, init_sticky, initialize_sticky, last_direction, last_scroll, offsets, placeholder, refresh_all_stickies, set_classes, state, static_interval, style, test_all_offsets, test_for_scroll_and_offsets, test_node_enter, test_node_exit, test_node_passing, test_node_scroll, test_on_scroll, ticking, trigger, update_everything, update_margins, update_metrics, update_offsets, update_sticky, win, win_height;
 
-  VERSION = '0.3.0';
+  VERSION = '0.3.1';
 
   offsets = {};
 
@@ -645,9 +645,9 @@
   };
 
   $.scrollKit.scrollTo = function(index, callback) {
-    var _offset, sticky;
-    sticky = state.contentNodes[index];
-    _offset = $(sticky).offset();
+    var _offset, contentNode;
+    contentNode = state.contentNodes[index];
+    _offset = $(contentNode).offset();
     html.animate({
       scrollTop: _offset.top - state.offsetTop
     }, 260, 'swing', callback);


### PR DESCRIPTION
This forces offset to update without calling recalc().
Cases: When contentNodes element height changes (wrong value - cached), or when element is replaced (no value).

_Gex case: playlist new items_
